### PR TITLE
Add xamarin way to use OSRemoteNotificationReceivedHandler

### DIFF
--- a/OneSignal.Android.Binding/Additions/NotificationExtenderBase.cs
+++ b/OneSignal.Android.Binding/Additions/NotificationExtenderBase.cs
@@ -1,0 +1,9 @@
+using AndroidX.Core.App;
+
+namespace Com.OneSignal.Android
+{
+    public abstract class NotificationExtenderBase : Java.Lang.Object, NotificationCompat.IExtender
+    {
+        public abstract NotificationCompat.Builder Extend(NotificationCompat.Builder builder);
+    }
+}

--- a/OneSignal.Android.Binding/Additions/OSRemoteNotificationReceivedBase.cs
+++ b/OneSignal.Android.Binding/Additions/OSRemoteNotificationReceivedBase.cs
@@ -1,0 +1,9 @@
+using Android.Content;
+
+namespace Com.OneSignal.Android
+{
+    public abstract class OSRemoteNotificationReceivedBase : Java.Lang.Object, OneSignal.IOSRemoteNotificationReceivedHandler
+    {
+        public abstract void RemoteNotificationReceived(Context ctx, OSNotificationReceivedEvent ev);
+    }
+}

--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -10,7 +10,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>OneSignal.Android.Binding</AssemblyName>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <AndroidClassParser>class-parse</AndroidClassParser>
@@ -54,6 +54,9 @@
   </ItemGroup>
   <ItemGroup>
     <LibraryProjectZip Include="Jars\onesignal-release.aar" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
 </Project>

--- a/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
+++ b/OneSignal.Android.Binding/OneSignal.Android.Binding.csproj
@@ -44,6 +44,9 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Additions\*.cs"/>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
   </ItemGroup>

--- a/OneSignal.Android.Binding/Transforms/EnumFields.xml
+++ b/OneSignal.Android.Binding/Transforms/EnumFields.xml
@@ -4,7 +4,7 @@
   and Fragment_tag from android.support.v4.app.FragmentActivity.FragmentTag
   to an enum called Android.Support.V4.App.FragmentTagType with values
   Id, Name, and Tag.
-  
+
   <mapping clr-enum-type="Android.Support.V4.App.FragmentTagType" jni-class="android/support/v4/app/FragmentActivity$FragmentTag">
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />

--- a/OneSignalSDK.Xamarin.Android/NotificationExtensionAttribute.cs
+++ b/OneSignalSDK.Xamarin.Android/NotificationExtensionAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Diagnostics;
+using Android.App;
+using Android.Content;
+
+namespace Com.OneSignal.Android
+{
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class NotificationExtensionAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
+    {
+        public string Name { get; set; }
+        public NotificationExtensionAttribute()
+        {
+        }
+    }
+}

--- a/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
+++ b/OneSignalSDK.Xamarin.Android/OneSignalSDK.Xamarin.Android.csproj
@@ -11,7 +11,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OneSignalSDK.Xamarin</RootNamespace>
     <AssemblyName>OneSignalSDK.Xamarin</AssemblyName>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidTlsProvider>
@@ -284,6 +284,7 @@
     </Compile>
     <Compile Include="Utilities\NativeConversion.cs" />
     <Compile Include="OneSignalCallbacks.cs" />
+    <Compile Include="NotificationExtensionAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OneSignal.Android.Binding\OneSignal.Android.Binding.csproj">

--- a/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
+++ b/Samples/OneSignalApp.Sample.Droid/OneSignalApp.Sample.Droid.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OneSignalApp.Sample.Droid</RootNamespace>
     <AssemblyName>OneSignalApp.Sample.Droid</AssemblyName>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>


### PR DESCRIPTION
# Description
## One Line Summary
 Add an easy way to use the OSRemoteNotificationReceivedHandler interface to replace old NotificationExtender in Xamarin .

## Details


Usage in xamarin project:
In manifest:
```xml
    <meta-data
        android:name="com.onesignal.NotificationServiceExtension"
        android:value="com.my.app.MyOneSignalServiceExtension" />
```

```cs
using System;
using Android.Content;
using AndroidX.Core.App;
using Com.OneSignal.Android;

namespace MyApp.Droid
{
    public class MyExtender : NotificationExtenderBase
    {
        public override NotificationCompat.Builder Extend(NotificationCompat.Builder builder)
        {
            //do something with builder
            return builder
                /*.AddAction(new NotificationCompat.Action(null, "coucou", null))*/
                ;
        }
    }

    [NotificationExtension(Name = "com.my.app.MyOneSignalServiceExtension")]
    public class NotificationExtender : OSRemoteNotificationReceivedBase
    {
        public override void RemoteNotificationReceived(Context _ctx, OSNotificationReceivedEvent ev)
        {
            var notif = ev.Notification.MutableCopy();
            notif.SetExtender(new MyExtender());

            if (notif?.AdditionalData == null)
            {
                ev.Complete(notif);
                return;
            }



            bool hideNotif = false;
            try
            {
                var discard = notif.AdditionalData.Get("silent");
                if (discard != null)
                {
                    hideNotif = true;
                }
            }
            catch (Exception /*e*/)
            {
            }
            ev.Complete(hideNotif ? null : notif);
        }
    }
}
```


I have made the following modification on the native android project: 
https://github.com/OneSignal/OneSignal-Android-SDK/compare/main...tmijieux:OneSignal-Android-SDK:use_OSRemoveNotificationReceivedHandler_in_xamarin

I'm not 100% sure the java code is required. I think we need the abstract base classes because if we just use the interface directly from csharp i'm not sure if there will be a peer object /peer class in java world resolvable with introspection.
Maybe it works with just the interface ? i will try it tomorrow.

NOTE: to make the native android code compile i had to upgrade minSdkVersion to 19 , you should probably recompile the native code on your side with your requirements

### Motivation
Since the update to 4.x it was unclear how to replace the NotificationExtenderService


### Scope
 This is only an extension, no existing feature should be affected.

# Affected code checklist
   - [ ] Notifications
      - [x] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Xamarin-SDK/381)
<!-- Reviewable:end -->
